### PR TITLE
add support for prefix and regex lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,25 @@
 # lua-resty-vhost
 
 Library for matching hostnames to values.
-Supports wildcard and `.hostname.tld` syntax in the same way as Nginx's [server_name](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_name) directive.
 
-Keys beginning with `.` or `*.` will match apex and all sub-domains, longest match wins. Non-wildcard matches always win.
+Supports wildcard, `.hostname.tld` or `www.hostname.` and regex in the same way as Nginx's [server_name](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_name) directive.
 
-Regex matches and prefix wildcards are not supported.
+Keys beginning with `.` or `*.` will match apex and all sub-domains, longest match wins. Non-wildcard matches always win. 
+Keys ending with `.` or `*` will match all hosts with that prefix. 
+Supports regex matches with `~regex` syntax as well.
 
-# Overview
+
+## Features
+
+- Exact match: `example.com`
+- Wildcard suffix match: `*.example.com` or `.example.com` 
+- Wildcard prefix match: `www.example.*` or `www.example.`
+- Regex match: `~^[a-z]+\.example\.com$`
+- Longest match wins for wildcard patterns
+- Support for removing entries
+- Support for retrieving multiple matches
+
+## Overview
 
 ```
 lua_package_path "/path/to/lua-resty-vhost/lib/?.lua;;";
@@ -19,6 +31,8 @@ init_by_lua_block {
     local ok, err = my_vhost:insert("www.example.com",  { key = "example.com.key",          cert = "example.com.crt" })
     local ok, err = my_vhost:insert(".sub.example.com", { key = "star.sub.example.com.key", cert = "star.sub.example.com.crt" })
     local ok, err = my_vhost:insert("www.example2.com", { key = "www.example2.com.key",     cert = "www.example2.com.crt" })
+    local ok, err = my_vhost:insert("~^[a-z]+\\.api\\.example\\.com$", { key = "api.key",   cert = "api.crt" })
+    local ok, err = my_vhost:insert("blog.example.",    { key = "blog.key",                 cert = "blog.crt" })
 }
 
 server {
@@ -56,7 +70,8 @@ server {
 }
 ```
 
-# Methods
+## Methods
+
 ### new
 `syntax: my_vhost, err = vhost:new(size?)`
 
@@ -67,7 +82,11 @@ Creates a new instance of resty-vhost with an optional initial size
 
 Adds a new hostname key with associated value.
 
-Keys must be strings.
+Keys can be:
+- String: `example.com` (exact match)
+- String starting with `.` or `*.`: `.example.com` (matches example.com and all subdomains)
+- String ending with `.` or `*`: `example.` (matches all hosts with example prefix)
+- String starting with `~`: `~[regex]` (regex match, will be converted to full match `^[regex]$`)
 
 Returns false and an error message on failure.
 
@@ -76,9 +95,50 @@ Returns false and an error message on failure.
 
 Retrieves value for best matching hostname entry.
 
+Priority order: exact match > longest suffix match > longest prefix match > regex match
+
 Returns nil and an error message on failure
 
+### remove
+`syntax: ok, err = my_vhost:remove(key)`
+
+Removes a hostname key from the vhost instance.
+
+Returns false and an error message on failure.
+
+### multi_lookup
+`syntax: tbl, err = my_vhost:multi_lookup(hostname, [table?])`
+
+Retrieves all matching values for a hostname entry and returns them in a table.
+
+Priority order: exact match > suffix matches > prefix matches > regex matches
+
+If provided, uses the given table for results, otherwise creates a new one.
+
+Returns a table containing all matched values, or nil and an error message on failure.
+
+### map_direct
+`syntax: val = my_vhost:map_direct([key])`
+
+Directly access the internal map storage.
+If no key is provided, returns the entire map.
+If a key is provided, returns the value associated with that key.
+
+## Match Priority
+
+The matching follows this priority order:
+
+1. Exact match: `example.com` matches `example.com`
+2. Longest suffix match: `sub.example.com` wins over `.example.com` when looking up `sub.example.com`
+3. Longest prefix match: `www.example.com` wins over `www.example.` when looking up `www.example.com` 
+4. Regex match: `~[regex]` (applied last)
+
+## Patterns
+
+- `example.com` - exact match only
+- `.example.com` or `*.example.com` - matches `example.com` and all subdomains like `www.example.com`, `api.example.com`
+- `example.` or `example.*` - matches `example.` prefix like `example.com`, `example.net` 
+- `~www\\.[a-z]+\\.example\\.com` - regex match (automatically wrapped with ^ and $)
+
 ## TODO
- * Regex matches
- * Prefix matches
- * Trie compression
+* Trie compression

--- a/lib/resty/vhost.lua
+++ b/lib/resty/vhost.lua
@@ -1,3 +1,6 @@
+local next = next
+local pairs = pairs
+local type = type
 local str_sub = string.sub
 local str_find = string.find
 local str_rev = string.reverse
@@ -7,6 +10,12 @@ local ngx_log = ngx.log
 local ngx_DEBUG = ngx.DEBUG
 local ngx_ERR = ngx.ERR
 local ngx_INFO = ngx.INFO
+local re_find = ngx.re.find
+
+local TYPE_REGEX = "regex"
+local TYPE_EXACT = "exact"
+local TYPE_SUFFIX = "suffix"
+local TYPE_PREFIX = "prefix"
 
 
 local ok, tab_new = pcall(require, "table.new")
@@ -15,7 +24,7 @@ if not ok then
 end
 
 local _M = {
-    _VERSION = "0.01",
+    _VERSION = "0.02",
 }
 local mt = { __index = _M }
 
@@ -27,40 +36,99 @@ end
 function _M.new(_, size)
     size = size or 10
     local self = {
-        trie = tab_new(0, size),
-        map = tab_new(0, size)
+        suffix_trie = tab_new(0, size),
+        prefix_trie = tab_new(0, size),
+        map = tab_new(0, size),
+        regex = tab_new(0, size)
     }
 
     return setmetatable(self, mt)
 end
 
 -- Splits domain name by . and adds to nested tables
-local function trie_insert(trie, val)
-    if val == "" then return end
-    if DEBUG then ngx_log(ngx_DEBUG, "Insert: '", val, "'") end
-    local pos = str_find(val, ".", 0, true)
+local function trie_insert(trie, key, val)
+    -- key: moc.elpmaxe.|elpmaxe.
+    if DEBUG then ngx_log(ngx_DEBUG, "Insert: '", key, "'") end
+    local pos = str_find(key, ".", 0, true)
     pos = pos or 0
-    local first = str_sub(val, 0, pos-1)
+    -- first: moc|elpmaxe
+    local first = str_sub(key, 0, pos-1)
     trie[first] = trie[first] or {}
-    if first ~= val then
-        trie_insert(trie[first], str_sub(val, pos+1))
+    key = str_sub(key, pos+1)
+    if key ~= "" then
+        -- trie_insert(trie["moc"], "elpmaxe.")
+        trie_insert(trie[first], key, val)
+    else
+        -- end
+        trie[first]["__val"] = val
+    end
+
+end
+
+local function trie_remove(trie, key)
+    if DEBUG then ngx_log(ngx_DEBUG, "Remove: '", key, "'") end
+    local pos = str_find(key, ".", 0, true)
+    pos = pos or 0
+    local first = str_sub(key, 0, pos-1)
+    if trie[first] then
+        key = str_sub(key, pos+1)
+        if key == "" then
+            -- Delete the node if it's the end of the key
+            trie[first]["__val"] = nil
+        else
+            trie_remove(trie[first], key)
+        end
+    end
+    -- clear if is empty
+    if not next(trie[first]) then
+        trie[first] = nil
     end
 end
 
-
-function _M.insert(self, key, val)
+local function parse_key(key)
     if not key or type(key) ~= "string" then
         return nil, "invalid key"
     end
+    local type = TYPE_EXACT
 
-    -- "*.example.com" is equivalent to ".example.com"
     local prefix = str_sub(key, 1, 1)
-    if prefix == '*' then
-        key = str_sub(key, 2, -1)
+    local suffix = str_sub(key, -1)
+    if prefix == '*' or prefix == '.' then           -- "*.example.com" is equivalent to ".example.com"
+        if prefix == '*' then
+            key = str_sub(key, 2, -1)
+        end
         prefix = str_sub(key, 1, 1)
         if prefix ~= "." then
             return false, "wildcards must be on label boundary"
         end
+        type = TYPE_SUFFIX
+    elseif prefix == '~' then       -- regex match: support ~regex
+        key = str_sub(key, 2, -1)
+        -- convert to full match
+        if str_sub(key, 1, 1) ~= "^" then
+            key = "^" .. key
+        end
+        if str_sub(key, -1) ~= "$" then
+            key = key .. "$"
+        end
+        type = TYPE_REGEX
+    elseif (suffix == "*" or suffix == ".") then    -- "www.example.*" is equivalent to "www.example."
+        if suffix == "*" then
+            key = str_sub(key, 1, -2)
+            suffix =  str_sub(key, -1)
+        end
+        if suffix ~= "." then
+            return false, "wildcards must be on label boundary"
+        end
+        type = TYPE_PREFIX
+    end
+    return type, key
+end
+
+function _M.insert(self, key, val)
+    local type, key = parse_key(key)
+    if not type then
+        return type, key
     end
 
     -- Cannot have duplicate entries
@@ -69,61 +137,167 @@ function _M.insert(self, key, val)
         return false, "key exists"
     end
 
-    -- Add to basic map
+    -- 1.Add to basic map
     map[key] = val
 
-    -- Add reversed string to trie if this is a wildcard key
-    if prefix == "." then
-        trie_insert(self.trie, str_rev(key))
+    -- 2.Add reversed string to suffix_trie
+    if type == TYPE_SUFFIX then
+
+        trie_insert(self.suffix_trie, str_rev(key), val)
+    end
+
+    -- 3.Add to prefix_trie
+    if type == TYPE_PREFIX then
+        trie_insert(self.prefix_trie, key, val)
+    end
+
+    -- 4.Add to regex map
+    if type == TYPE_REGEX then
+        self.regex[key] = val
+    end
+    return true
+end
+
+function _M.remove(self, key)
+
+    local type, key = parse_key(key)
+    if not type then
+        return type, key
+    end
+
+    -- Make sure exists
+    local map = self.map
+    if not map[key] then
+        return false, "key not exists"
+    end
+
+    -- Remove from basic map
+    map[key] = nil
+
+    -- Remove from suffix_trie
+    if type == TYPE_SUFFIX then
+        trie_remove(self.suffix_trie, str_rev(key))
+    end
+
+    -- Remove from prefix_trie
+    if type == TYPE_PREFIX then
+        trie_remove(self.prefix_trie, key)
+    end
+
+    -- Remove from regex
+    if type == TYPE_REGEX then
+        self.regex[key] = nil
     end
     return true
 end
 
 
-local function trie_walk(trie, key, ret, tbl_pos)
-    tbl_pos = tbl_pos or 1
+local function trie_walk(trie, key, last_matched_val, tbl)  -- key:moc.elpmaxe.ao, elpmaxe.ao
     local pos = str_find(key, ".", 0, true)
     pos = pos or 0
-    local first = str_sub(key, 0, pos-1)
+    local first = str_sub(key, 0, pos-1)    -- first:moc| elpmaxe
 
     if first ~= "" and trie[first] then
-        if DEBUG then ngx_log(ngx_DEBUG, "found ", first) end
-        ret[tbl_pos] = first
-        ret[tbl_pos+1] = "."
-        tbl_pos = trie_walk(trie[first], str_sub(key, pos+1), ret, tbl_pos+2)
+        local current = trie[first]["__val"]
+        if (tbl and current) then
+            tbl_insert(tbl, tbl.__base+1, current)
+        end
+        if current then
+            last_matched_val = current
+        end
+        if DEBUG then ngx_log(ngx_INFO, "found ", first) end
+        return trie_walk(trie[first], str_sub(key, pos+1), last_matched_val, tbl)
     end
-    return tbl_pos
+    return last_matched_val
 end
 
-
+-- Returns best match: priority: exact match > longest suffix match > longest prefix match > regex match
 function _M.lookup(self, key)
     if not key or type(key) ~= "string" then
         return nil, "invalid key"
     end
 
-    -- Attempt to match full string first
+    -- 1.Attempt to match full string first
     local match = self.map[key]
     if match then
         return match
     end
 
-    -- Search the wildcard trie
+    -- 2.Search the suffix_trie
     if DEBUG then ngx_log(ngx_DEBUG, "Searching: ", key) end
-    local match = {}
-    local tbl_pos = trie_walk(self.trie, str_rev(key), match)
 
-    -- Partial matches don't count
-    local len = tbl_pos -1
-    if len == 0 or match[len] ~= "." then
-        if DEBUG then ngx_log(ngx_DEBUG, "Partial match: ", str_rev(tbl_concat(match, ""))) end
-        return nil
+    local val = trie_walk(self.suffix_trie, str_rev(key), nil)
+
+    if val then
+        return val
     end
 
-    -- Convert back to a string and return the value
-    match = str_rev(tbl_concat(match, ""))
-    if DEBUG then ngx_log(ngx_DEBUG, "Found: ", match) end
-    return self.map[match]
+    -- 3.Search the prefix_trie
+    val = trie_walk(self.prefix_trie, key, nil)
+
+    if val then
+        return val
+    end
+
+    if DEBUG then ngx_log(ngx_DEBUG, "Try regex match") end
+    -- 4.Search regex
+    for re, val in pairs(self.regex) do
+        if re_find(key, re, "ijo") then
+            return val
+        end
+    end
+    return nil
+end
+
+-- tbl: contains all matched records, priority: exact match > longest suffix match > longest prefix match > regex match
+function _M.multi_lookup(self, key, tbl)
+    if not key or type(key) ~= "string" then
+        return nil, "invalid key"
+    end
+
+    if not tbl then
+        tbl = tab_new(5, 0)
+    end
+
+    -- 1.Attempt to match full string first
+    local match = self.map[key]
+
+
+    if DEBUG then ngx_log(ngx_DEBUG, "Searching: ", key) end
+
+    -- 2.Search suffix_trie, insert matched to tbl
+    tbl.__base = #tbl
+    trie_walk(self.suffix_trie, str_rev(key), nil, tbl)
+
+    -- 3.Search prefix_trie, insert matched to tbl
+    tbl.__base = #tbl
+    trie_walk(self.prefix_trie, key, nil, tbl)
+
+    if match then
+        tbl_insert(tbl, 1, match)
+    end
+
+    if DEBUG then ngx_log(ngx_DEBUG, "Try regex match") end
+    -- 4.Search regex
+    for re, val in pairs(self.regex) do
+        if re_find(key, re, "ijo") then
+            tbl_insert(tbl, val)
+        end
+    end
+    return tbl
+end
+
+function _M.map_direct(self, key)
+    if not key then
+        return self.map
+    end
+
+    local type, key = parse_key(key)
+    if not type then
+        return type, key
+    end
+
+    return self.map[key]
 end
 
 return _M
-

--- a/spec/01-vhost_spec.lua
+++ b/spec/01-vhost_spec.lua
@@ -1,0 +1,167 @@
+local vhost = require("resty.vhost")
+describe("router",function()
+    local my_vhost
+    it("new",function()
+        my_vhost = vhost.new(100, 200)
+        assert.is_not_nil(vhost)
+    end)
+
+    it("insert",function()
+        local res, err
+        res,err = my_vhost:insert("mail.local.example.cn", 1)
+        assert.is_true(res)
+        res,err = my_vhost:insert("mail.local.example.cn", 1)
+        assert.is_false(res)
+        assert.is_not_nil(err)
+
+        res,err = my_vhost:insert(".local.example.cn", 2)
+        assert.is_true(res)
+        assert.is_nil(err)
+        res,err = my_vhost:insert("*.local.example.cn", 2)
+        assert.is_false(res)
+        assert.is_not_nil(err)  -- "key exists"
+
+        res,err = my_vhost:insert("www.local.example.*", 3)
+        assert.is_true(res)
+        assert.is_nil(err)
+        res,err = my_vhost:insert("www.local.example.", 3)
+        assert.is_false(res)
+        assert.is_not_nil(err)  -- "key exists"
+
+        res,err = my_vhost:insert("www.local.", 4)
+        assert.is_true(res)
+        assert.is_nil(err)
+        res,err = my_vhost:insert("www.local.*", 4)
+        assert.is_false(res)
+        assert.is_not_nil(err)  -- "key exists"
+
+
+        res,err = my_vhost:insert([[~www\.\d{3}\.example.cn]], 5)
+        assert.is_true(res)
+        assert.is_nil(err)
+        res,err = my_vhost:insert([[~www\.\d{3}\.example.cn$]], 5)
+        assert.is_false(res)
+        assert.is_not_nil(err)  -- "key exists"
+        res,err = my_vhost:insert([[~^www\.\d{3}\.example.cn]], 5)
+        assert.is_false(res)
+        assert.is_not_nil(err)  -- "key exists"
+        local res,err = my_vhost:insert([[~^mail\.[a-z]{3,5}\.example.cn]], 6)
+        assert.is_true(res)
+        assert.is_nil(err)
+        local res,err = my_vhost:insert([[~^www\.[a-z]{3,5}\.example.cn]], 7)
+        assert.is_true(res)
+        assert.is_nil(err)
+    end)
+
+    it("lookup",function()
+        local match, err = my_vhost:lookup(nil)
+        assert.is_nil(match)
+        assert.is_not_nil(err)
+
+        match, err = my_vhost:lookup("www.1234.example.com")
+        assert.is_nil(match)
+
+        match, err = my_vhost:lookup("www.prd.example.cn")
+        assert.is_true(match == 7)
+
+        match, err = my_vhost:lookup("mail.prd.example.cn")
+        assert.is_true(match == 6)
+
+        match, err = my_vhost:lookup("www.123.example.cn")
+        assert.is_true(match == 5)
+
+
+        match, err = my_vhost:lookup("www.local.test.cn")
+        assert.is_true(match == 4)
+
+        match, err = my_vhost:lookup("www.local.example.com")
+        assert.is_true(match == 3)
+
+        match, err = my_vhost:lookup("www.local.example.cn")
+        assert.is_true(match == 2)
+
+        match, err = my_vhost:lookup("mail.local.example.cn")
+        assert.is_true(match == 1)
+
+        match, err = my_vhost:lookup("www.testtest.example.cn")
+        assert.is_nil(match)
+    end)
+
+    it("multi_lookup",function()
+        local t = {}
+        local t1 = my_vhost:multi_lookup("mail.local.example.cn", t)
+        assert.is_true(t == t1)
+        assert.is_true(#t == 3)
+        assert.is_true(t[1] == 1)
+        assert.is_true(t[2] == 2)
+        assert.is_true(t[3] == 6)
+
+        local t2 = my_vhost:multi_lookup("www.local.example.cn")
+        assert.is_false(t == t2)
+        assert.is_true(#t2 == 4)
+        assert.is_true(t2[1] == 2)
+        assert.is_true(t2[2] == 3)
+        assert.is_true(t2[3] == 4)
+        assert.is_true(t2[4] == 7)
+    end)
+
+    it("lookup dynamic",function()
+        local res, err = my_vhost:remove([[~mail\.[a-z]{3,5}\.example.cn]])
+        assert.is_true(res)
+        assert.is_nil(err)
+        local match, err = my_vhost:lookup("mail.prd.example.cn")
+        assert.is_nil(match)
+        match, err = my_vhost:lookup("mail.local.example.cn")
+        assert.is_true(match == 1)
+
+        local t = my_vhost:multi_lookup("mail.local.example.cn")
+        assert.is_true(#t == 2)
+        assert.is_true(t[1] == 1)
+        assert.is_true(t[2] == 2)
+
+
+        res, err = my_vhost:remove("mail.local.example.cn")
+        assert.is_true(res)
+        assert.is_nil(err)
+        match, err = my_vhost:lookup("mail.local.example.cn")
+        assert.is_true(match == 2)
+        t = my_vhost:multi_lookup("mail.local.example.cn")
+        assert.is_true(#t == 1)
+        assert.is_true(t[1] == 2)
+
+        res, err = my_vhost:remove(".local.example.cn", 2)
+        assert.is_true(res)
+        assert.is_nil(err)
+        match, err = my_vhost:lookup("mail.local.example.cn")
+        assert.is_nil(match)
+        t = my_vhost:multi_lookup("mail.local.example.cn")
+        assert.is_true(#t == 0)
+
+        match, err = my_vhost:lookup("www.local.example.cn")
+        assert.is_true(match == 3)
+        t = my_vhost:multi_lookup("www.local.example.cn")
+        assert.is_true(#t == 3)
+        assert.is_true(t[1] == 3)
+        assert.is_true(t[2] == 4)
+        assert.is_true(t[3] == 7)
+
+        res, err = my_vhost:remove("www.local.example.*")
+        assert.is_true(res)
+        assert.is_nil(err)
+        match, err = my_vhost:lookup("www.local.example.cn")
+        assert.is_true(match == 4)
+        t = my_vhost:multi_lookup("www.local.example.cn")
+        assert.is_true(#t == 2)
+        assert.is_true(t[1] == 4)
+        assert.is_true(t[2] == 7)
+
+        res, err = my_vhost:remove("www.local.*")
+        assert.is_true(res)
+        assert.is_nil(err)
+        match, err = my_vhost:lookup("www.local.example.cn")
+        assert.is_true(match == 7)
+        t = my_vhost:multi_lookup("www.local.example.cn")
+        assert.is_true(#t == 1)
+        assert.is_true(t[1] == 7)
+    end)
+end)

--- a/t/02-prefix-regex.t
+++ b/t/02-prefix-regex.t
@@ -1,0 +1,256 @@
+use Test::Nginx::Socket;
+use Cwd qw(cwd);
+
+plan tests => repeat_each() * 27;
+
+my $pwd = cwd();
+
+$ENV{TEST_LEDGE_REDIS_DATABASE} ||= 1;
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+};
+
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: Prefix matching basic test
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local ok, err = my_vhost:insert("www.example.", "prefix match")
+            local val = my_vhost:lookup("www.example.com")
+            ngx.say(val)
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+prefix match
+
+=== TEST 2: Prefix matching with different domains
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local ok, err = my_vhost:insert("api.", "api prefix")
+            local val1 = my_vhost:lookup("api.service1.com")
+            local val2 = my_vhost:lookup("api.service2.net")
+            ngx.say(val1)
+            ngx.say(val2)
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+api prefix
+api prefix
+
+=== TEST 3: Prefix matching priority over regex
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local ok, err = my_vhost:insert("test.", "prefix match")
+            local ok, err = my_vhost:insert("~^test\\.[a-z]+\\.com$", "regex match")
+            local val = my_vhost:lookup("test.example.com")
+            ngx.say(val)
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+prefix match
+
+=== TEST 4: Regex matching basic test
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local ok, err = my_vhost:insert("~^www\\.[a-z]+\\.example\\.com$", "regex www.*.example.com")
+            local val = my_vhost:lookup("www.test.example.com")
+            ngx.say(val)
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+regex www.*.example.com
+
+=== TEST 5: Regex matching with numbers
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local ok, err = my_vhost:insert("~^api\\-[0-9]+\\.service\\..*$", "regex api-*.service.*")
+            local val = my_vhost:lookup("api-123.service.company.com")
+            ngx.say(val)
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+regex api-*.service.*
+
+=== TEST 6: Regex not matching incorrect format
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local ok, err = my_vhost:insert("~^www\\.[a-z]+\\.example\\.com$", "regex match")
+            local val1 = my_vhost:lookup("www123.test.example.com")  -- No dot between www and test
+            local val2 = my_vhost:lookup("www.test.example.org")    -- Different TLD than regex
+            ngx.say(val1 or "nil")
+            ngx.say(val2 or "nil")
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+nil
+nil
+
+=== TEST 7: Prefix removal test
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local ok, err = my_vhost:insert("test.", "prefix test")
+            local val1 = my_vhost:lookup("test.domain.com")
+
+            local ok, err = my_vhost:remove("test.")
+            local val2 = my_vhost:lookup("test.domain.com")
+
+            ngx.say(val1)
+            ngx.say(val2 or "nil")
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+prefix test
+nil
+
+=== TEST 8: Regex removal test
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local ok, err = my_vhost:insert("~^temp\\-[a-z]+$", "regex temp")
+            local val1 = my_vhost:lookup("temp-abc")
+
+            local ok, err = my_vhost:remove("~^temp\\-[a-z]+$")
+            local val2 = my_vhost:lookup("temp-abc")
+
+            ngx.say(val1)
+            ngx.say(val2 or "nil")
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+regex temp
+nil
+
+=== TEST 9: Mixed matching with proper priorities
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+
+            -- Insert in different orders to test priority
+            local ok, err = my_vhost:insert("~^regex\\-[0-9]+\\.test$", "regex match")
+            local ok, err = my_vhost:insert("prefix.", "prefix match")
+            local ok, err = my_vhost:insert(".suffix.example.com", "suffix match")
+            local ok, err = my_vhost:insert("exact.example.com", "exact match")
+
+            -- Test exact match (highest priority)
+            local val1 = my_vhost:lookup("exact.example.com")
+
+            -- Test suffix match (second priority)
+            local val2 = my_vhost:lookup("sub.suffix.example.com")
+
+            -- Test prefix match (third priority)
+            local val3 = my_vhost:lookup("prefix.anything.com")
+
+            -- Test regex match (lowest priority)
+            local val4 = my_vhost:lookup("regex-123.test")
+            ngx.say(val1)
+            ngx.say(val2)
+            ngx.say(val3)
+            ngx.say(val4)
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+exact match
+suffix match
+prefix match
+regex match

--- a/t/03-error-handling.t
+++ b/t/03-error-handling.t
@@ -1,0 +1,170 @@
+use Test::Nginx::Socket;
+use Cwd qw(cwd);
+
+plan tests => repeat_each() * 18;
+
+my $pwd = cwd();
+
+$ENV{TEST_LEDGE_REDIS_DATABASE} ||= 1;
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+};
+
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: Invalid prefix key format
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local ok, err = my_vhost:insert("invalid*", "should fail")
+            ngx.say(ok)
+            ngx.say(err or "nil")
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+false
+wildcards must be on label boundary
+
+=== TEST 2: Invalid suffix key format
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local ok, err = my_vhost:insert("*invalid", "should fail")
+            ngx.say(ok)
+            ngx.say(err or "nil")
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+false
+wildcards must be on label boundary
+
+=== TEST 3: Duplicate key insertion
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local ok1, err1 = my_vhost:insert("example.com", "first")
+            local ok2, err2 = my_vhost:insert("example.com", "second")
+            ngx.say(ok1)
+            ngx.say(err1 or "nil")
+            ngx.say(ok2)
+            ngx.say(err2 or "nil")
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+true
+nil
+false
+key exists
+
+=== TEST 4: Remove non-existent key
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local ok, err = my_vhost:remove("nonexistent.com")
+            ngx.say(ok)
+            ngx.say(err or "nil")
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+false
+key not exists
+
+=== TEST 5: Lookup with invalid input
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local val1, err1 = my_vhost:lookup(nil)
+            local val2, err2 = my_vhost:lookup(123)
+            ngx.say(val1 or "nil")
+            ngx.say(err1 or "nil")
+            ngx.say(val2 or "nil")
+            ngx.say(err2 or "nil")
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+nil
+invalid key
+nil
+invalid key
+
+=== TEST 6: Insert with invalid key
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local ok1, err1 = my_vhost:insert(nil, "value")
+            local ok2, err2 = my_vhost:insert(123, "value")
+            ngx.say(ok1)
+            ngx.say(err1 or "nil")
+            ngx.say(ok2)
+            ngx.say(err2 or "nil")
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+nil
+invalid key
+nil
+invalid key

--- a/t/04-multi-lookup.t
+++ b/t/04-multi-lookup.t
@@ -1,0 +1,277 @@
+use Test::Nginx::Socket;
+use Cwd qw(cwd);
+
+plan tests => repeat_each() * 30;
+
+my $pwd = cwd();
+
+$ENV{TEST_LEDGE_REDIS_DATABASE} ||= 1;
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+};
+
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: Basic prefix matching
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local ok, err = my_vhost:insert("www.", "www prefix")
+            local val = my_vhost:lookup("www.example.com")
+            ngx.say(val)
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+www prefix
+
+=== TEST 2: Basic regex matching
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local ok, err = my_vhost:insert("~^www\\.[a-z]+\\.example\\.com$", "www regex")
+            local val = my_vhost:lookup("www.test.example.com")
+            ngx.say(val)
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+www regex
+
+=== TEST 3: Exact match priority
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+            local ok, err = my_vhost:insert("exact.com", "exact match")
+            local ok, err = my_vhost:insert(".com", "suffix match")
+            local val = my_vhost:lookup("exact.com")
+            ngx.say(val)
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+exact match
+
+=== TEST 4: Multi lookup basic functionality
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+
+            -- Insert matches of different types
+            local ok, err = my_vhost:insert("exact.com", "exact match")
+            local ok, err = my_vhost:insert(".com", "suffix match")
+
+            local results = my_vhost:multi_lookup("exact.com")
+            ngx.say(#results)
+            ngx.say(results[1])
+            ngx.say(results[2] or "nil")
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+2
+exact match
+suffix match
+
+=== TEST 5: Multi lookup with no matches
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+
+            local results = my_vhost:multi_lookup("nonexistent.com")
+            ngx.say(#results)
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+0
+
+=== TEST 6: Multi lookup reusing table
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+
+            local ok, err = my_vhost:insert("exact.com", "exact match")
+            local ok, err = my_vhost:insert(".com", "suffix match")
+
+            local tbl = {}
+            tbl.test_field = "existing"
+
+            local results = my_vhost:multi_lookup("exact.com", tbl)
+
+            ngx.say(results == tbl)
+            ngx.say(tbl.test_field)
+            ngx.say(#results)
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+true
+existing
+2
+
+=== TEST 7: Empty table behavior
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+
+            local results = my_vhost:multi_lookup("test.com")
+            ngx.say(type(results))
+            ngx.say(#results)
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+table
+0
+
+=== TEST 8: Regex matching with multiple patterns
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+
+            local ok, err = my_vhost:insert("~^www\\.[a-z]+\\.com$", "www regex")
+            local ok, err = my_vhost:insert("~^api\\-[0-9]+\\.com$", "api regex")
+
+            local val1 = my_vhost:lookup("www.test.com")
+            local val2 = my_vhost:lookup("api-123.com")
+            ngx.say(val1)
+            ngx.say(val2)
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+www regex
+api regex
+
+=== TEST 9: Prefix and suffix combined
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+
+            local ok, err = my_vhost:insert("www.", "www prefix")
+            local ok, err = my_vhost:insert(".example.com", "example suffix")
+
+            local val1 = my_vhost:lookup("www.test.com")
+            local val2 = my_vhost:lookup("test.example.com")
+            ngx.say(val1 or "nil")
+            ngx.say(val2 or "nil")
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+www prefix
+example suffix
+
+=== TEST 10: Complex priority test
+--- http_config eval
+"$::HttpConfig"
+. q{
+}
+--- config
+    location /a {
+        content_by_lua_block {
+            local vhost = require("resty.vhost")
+            local my_vhost = vhost:new(10)
+
+            -- Insert in different orders to test priority
+            local ok, err = my_vhost:insert("~^test\\.[a-z]+\\.com$", "regex match")
+            local ok, err = my_vhost:insert("test.", "prefix match")
+            local ok, err = my_vhost:insert(".test.com", "suffix match")
+            local ok, err = my_vhost:insert("exact.test.com", "exact match")
+
+            local val = my_vhost:lookup("exact.test.com")
+            ngx.say(val)
+        }
+    }
+--- request
+GET /a
+--- no_error_log
+[error]
+--- response_body
+exact match


### PR DESCRIPTION
Add support for prefix and regex lookup.

Key changes include:
- Added support for wildcard prefix matching using patterns like www.example.* or www.example.
- Added support for regex matching using patterns starting with ~ such as ~^[a-z]+\\.api\\.example\\.com$
- Added support for removing entries via the remove method
- Added support for retrieving multiple matches via the multi_lookup method
- Improved matching logic to handle all pattern types with proper priority ordering

The implementation maintains backward compatibility while extending the hostname matching capabilities to support more complex use cases including:
- Exact match: example.com
- Wildcard suffix match: *.example.com or .example.com
- Wildcard prefix match: www.example.* or www.example.
- Regex match: ~^[a-z]+\.example\.com$
- Longest match wins for wildcard patterns
- Support for removing entries
- Support for retrieving multiple matches